### PR TITLE
19 buf fix ssvqe

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The default options for VQE are as follows:
 You can change those options via arguments for `VQECASCI` and `VQECASSCF` objects, which are then passed to `VQECI` objects. Please see [`chemqulacs.vqe.vqeci` module](https://wmizukami.github.io/chemqulacs/chemqulacs.vqe.vqeci.html) for more details.
 
 
-You can also change number of excited states to calculate.
+You can also change number of excited states to calculate. SSVQE is used for excited-state calculations by the VQECASCI and VQECASSCF classes
 ```python
 from pyscf import gto, scf
 from chemqulacs.util import utils

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The default options for VQE are as follows:
 You can change those options via arguments for `VQECASCI` and `VQECASSCF` objects, which are then passed to `VQECI` objects. Please see [`chemqulacs.vqe.vqeci` module](https://wmizukami.github.io/chemqulacs/chemqulacs.vqe.vqeci.html) for more details.
 
 
-You can also change number of excited states to calculate. SSVQE is used for excited-state calculations by the VQECASCI and VQECASSCF classes
+You can also change number of excited states to calculate. SSVQE is used for excited-state calculations by the VQECASCI and VQECASSCF classes.
 ```python
 from pyscf import gto, scf
 from chemqulacs.util import utils

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can also change number of excited states to calculate.
 from pyscf import gto, scf
 from chemqulacs.util import utils
 from chemqulacs.vqe.vqemcscf import VQECASCI, VQECASSCF
+from chemqulacs.vqe.vqeci import Ansatz
+from quri_parts.algo.optimizer import LBFGS
 
 # Retrieve geometry of a water molecule from PubChem
 geom_water = utils.get_geometry_from_pubchem("water")
@@ -70,8 +72,7 @@ mf = scf.RHF(mol)
 mf.run()
 
 # Run CASCI with VQE with CAS(2e, 2o)
-vqe_casci = VQECASCI(mf, 2, 2)
-vqe_casci.fcisolver.nroots = 5
+vqe_casci = VQECASCI(mf, 2, 2, optimizer=LBFGS(), ansatz=Ansatz.GateFabric, layers=2, excitation_number=5)
 vqe_casci.kernel()
 print(f"VQE-CASCI Energis: {vqe_casci.fcisolver.energies}")
 
@@ -84,8 +85,7 @@ vqe_casci.print_energies()
 #     S3      -74.528864      11.8528                 1 -> 3
 
 # Run CASSCF with VQE with CAS(2e, 2o)
-vqe_casscf = VQECASSCF(mf, 2, 2)
-vqe_casci.fcisolver.nroots = 5
+vqe_casscf = VQECASSCF(mf, 2, 2, optimizer=LBFGS(), ansatz=Ansatz.GateFabric, layers=2, excitation_number=5)
 vqe_casscf.kernel()
 print(f"VQE-CASSCF Energis: {vqe_casci.fcisolver.energies}")
 vqe_casscf.print_energies()

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -320,8 +320,8 @@ def vqe(init_params, cost_fn, grad_fn, optimizer):
     return opt_state
 
 
-def _generate_inital_states(
-    n_electron, n_orbitals, excitation_number=0, fermion_qubit_mapping=jordan_wigner
+def generate_initial_states(
+    n_orbitals, n_electron, excitation_number=0, fermion_qubit_mapping=jordan_wigner
 ):
     for m in range(n_electron, 2 * n_electron + 1):
         if comb(m, n_electron) >= excitation_number + 1:
@@ -350,7 +350,7 @@ class VQECI(object):
             optimizer
             backend (Backend)
             shots_per_iter (int)
-            inital_states (optional): Inital states for VQE
+            initial_states (optional): Initial states for VQE
             ansatz: ansatz used for VQE
             layers (int):
                 Layers of gate operations. Used for ``HardwareEfficient``, ``SymmetryPreserving``, ``ParticleConservingU1``, ``ParticleConservingU2``, and ``GateFabric``.
@@ -382,7 +382,7 @@ class VQECI(object):
         optimizer=Adam(),
         backend: Backend = QulacsBackend(),
         shots_per_iter: int = 10000,
-        inital_states=None,
+        initial_states=None,
         ansatz: Ansatz = Ansatz.ParticleConservingU1,
         layers: int = 2,
         k: int = 1,
@@ -403,7 +403,7 @@ class VQECI(object):
         self.opt_states: list = [None]
         self.n_qubit: int = None
         self.n_orbitals: int = None
-        self.initial_states = inital_states
+        self.initial_states = initial_states
         self.ansatz: Ansatz = ansatz
         self.optimizer = optimizer
         self.n_electron: int = None
@@ -446,9 +446,9 @@ class VQECI(object):
         # Set initial Quantum State
 
         if self.initial_states is None:
-            self.initial_states = _generate_inital_states(
-                self.n_electron,
+            self.initial_states = generate_initial_states(
                 self.n_orbitals,
+                self.n_electron,
                 self.excitation_number,
                 self.fermion_qubit_mapping,
             )

--- a/chemqulacs/vqe/vqemcscf.py
+++ b/chemqulacs/vqe/vqemcscf.py
@@ -77,6 +77,7 @@ class VQECASCI(casci.CASCI):
             optimizer
             backend (Backend)
             shots_per_iter (int)
+            inital_states (optional): Inital states for VQE
             ansatz: ansatz used for VQE
             layers (int):
                 Layers of gate operations. Used for ``HardwareEfficient``, ``SymmetryPreserving``, ``ParticleConservingU1``, ``ParticleConservingU2``, and ``GateFabric``.
@@ -119,6 +120,7 @@ class VQECASCI(casci.CASCI):
         backend: Backend = QulacsBackend(),
         shots_per_iter: int = 10000,
         ansatz: Ansatz = Ansatz.ParticleConservingU1,
+        inital_states=None,
         layers: int = 1,
         k: int = 1,
         trotter_number: int = 1,
@@ -138,6 +140,7 @@ class VQECASCI(casci.CASCI):
             optimizer=optimizer,
             backend=backend,
             shots_per_iter=shots_per_iter,
+            inital_states=inital_states,
             ansatz=ansatz,
             layers=layers,
             k=k,
@@ -171,6 +174,7 @@ class VQECASSCF(mc1step.CASSCF):
             optimizer
             backend (Backend)
             shots_per_iter (int)
+            inital_states (optional): Inital states for VQE
             ansatz: ansatz used for VQE
             layers (int):
                 Layers of gate operations. Used for ``HardwareEfficient``, ``SymmetryPreserving``, ``ParticleConservingU1``, ``ParticleConservingU2``, and ``GateFabric``.
@@ -213,6 +217,7 @@ class VQECASSCF(mc1step.CASSCF):
         optimizer=Adam(),
         backend: Backend = QulacsBackend(),
         shots_per_iter: int = 10000,
+        inital_states=None,
         ansatz: Ansatz = Ansatz.ParticleConservingU1,
         layers: int = 1,
         k: int = 1,
@@ -233,6 +238,7 @@ class VQECASSCF(mc1step.CASSCF):
             optimizer=optimizer,
             backend=backend,
             shots_per_iter=shots_per_iter,
+            inital_states=inital_states,
             ansatz=ansatz,
             layers=layers,
             k=k,

--- a/chemqulacs/vqe/vqemcscf.py
+++ b/chemqulacs/vqe/vqemcscf.py
@@ -77,7 +77,7 @@ class VQECASCI(casci.CASCI):
             optimizer
             backend (Backend)
             shots_per_iter (int)
-            inital_states (optional): Inital states for VQE
+            initial_states (optional): Initial states for VQE
             ansatz: ansatz used for VQE
             layers (int):
                 Layers of gate operations. Used for ``HardwareEfficient``, ``SymmetryPreserving``, ``ParticleConservingU1``, ``ParticleConservingU2``, and ``GateFabric``.
@@ -120,7 +120,7 @@ class VQECASCI(casci.CASCI):
         backend: Backend = QulacsBackend(),
         shots_per_iter: int = 10000,
         ansatz: Ansatz = Ansatz.ParticleConservingU1,
-        inital_states=None,
+        initial_states=None,
         layers: int = 1,
         k: int = 1,
         trotter_number: int = 1,
@@ -140,7 +140,7 @@ class VQECASCI(casci.CASCI):
             optimizer=optimizer,
             backend=backend,
             shots_per_iter=shots_per_iter,
-            inital_states=inital_states,
+            initial_states=initial_states,
             ansatz=ansatz,
             layers=layers,
             k=k,
@@ -174,7 +174,7 @@ class VQECASSCF(mc1step.CASSCF):
             optimizer
             backend (Backend)
             shots_per_iter (int)
-            inital_states (optional): Inital states for VQE
+            initial_states (optional): Initial states for VQE
             ansatz: ansatz used for VQE
             layers (int):
                 Layers of gate operations. Used for ``HardwareEfficient``, ``SymmetryPreserving``, ``ParticleConservingU1``, ``ParticleConservingU2``, and ``GateFabric``.
@@ -217,7 +217,7 @@ class VQECASSCF(mc1step.CASSCF):
         optimizer=Adam(),
         backend: Backend = QulacsBackend(),
         shots_per_iter: int = 10000,
-        inital_states=None,
+        initial_states=None,
         ansatz: Ansatz = Ansatz.ParticleConservingU1,
         layers: int = 1,
         k: int = 1,
@@ -238,7 +238,7 @@ class VQECASSCF(mc1step.CASSCF):
             optimizer=optimizer,
             backend=backend,
             shots_per_iter=shots_per_iter,
-            inital_states=inital_states,
+            initial_states=initial_states,
             ansatz=ansatz,
             layers=layers,
             k=k,

--- a/tests/test_vqe_vqemcscf.py
+++ b/tests/test_vqe_vqemcscf.py
@@ -46,8 +46,8 @@ def test_vqecasci_h2o_2e_2o():
 
 def test_ssvqecasci_h2o_2e_2o():
 
-    n_electrons = 2
     n_orbitals = 2
+    n_electrons = 2
     excitation_number = 5
 
     # Generate initial states
@@ -69,8 +69,8 @@ def test_ssvqecasci_h2o_2e_2o():
 
     mc = vqemcscf.VQECASCI(
         mf,
-        n_electrons,
         n_orbitals,
+        n_electrons,
         optimizer=LBFGS(),
         initial_states=initial_states,
         ansatz=Ansatz.GateFabric,
@@ -117,5 +117,3 @@ def test_vqecasscf_h2o_2e_2o():
 
     assert utils.almost_equal(mc.e_tot, refmc.e_tot)
 
-
-test_ssvqecasci_h2o_2e_2o()

--- a/tests/test_vqe_vqemcscf.py
+++ b/tests/test_vqe_vqemcscf.py
@@ -8,6 +8,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from math import pi
+
 from pyscf import gto, mcscf, scf
 from quri_parts.algo.optimizer import LBFGS
 from quri_parts.core.state import comp_basis_superposition
@@ -15,8 +17,6 @@ from quri_parts.core.state import comp_basis_superposition
 from chemqulacs.util import utils
 from chemqulacs.vqe import vqemcscf
 from chemqulacs.vqe.vqeci import Ansatz, _generate_inital_states
-
-from math import pi
 
 
 geom_water = utils.get_geometry_from_pubchem("water")

--- a/tests/test_vqe_vqemcscf.py
+++ b/tests/test_vqe_vqemcscf.py
@@ -116,4 +116,3 @@ def test_vqecasscf_h2o_2e_2o():
     refmc.mc2step()
 
     assert utils.almost_equal(mc.e_tot, refmc.e_tot)
-

--- a/tests/test_vqe_vqemcscf.py
+++ b/tests/test_vqe_vqemcscf.py
@@ -18,7 +18,6 @@ from chemqulacs.util import utils
 from chemqulacs.vqe import vqemcscf
 from chemqulacs.vqe.vqeci import Ansatz, _generate_inital_states
 
-
 geom_water = utils.get_geometry_from_pubchem("water")
 mol = gto.M(atom=geom_water, basis="sto-3g")
 mf = scf.RHF(mol)

--- a/tests/test_vqe_vqemcscf.py
+++ b/tests/test_vqe_vqemcscf.py
@@ -10,10 +10,14 @@
 
 from pyscf import gto, mcscf, scf
 from quri_parts.algo.optimizer import LBFGS
+from quri_parts.core.state import comp_basis_superposition
 
 from chemqulacs.util import utils
 from chemqulacs.vqe import vqemcscf
-from chemqulacs.vqe.vqeci import Ansatz
+from chemqulacs.vqe.vqeci import Ansatz, _generate_inital_states
+
+from math import pi
+
 
 geom_water = utils.get_geometry_from_pubchem("water")
 mol = gto.M(atom=geom_water, basis="sto-3g")
@@ -42,31 +46,52 @@ def test_vqecasci_h2o_2e_2o():
 
 
 def test_ssvqecasci_h2o_2e_2o():
+
+    n_electron = 2
+    n_orbitals = 2
+    excitation_number = 5
+
+    # Generate inital states
+    inital_states = _generate_inital_states(n_electron, n_orbitals, excitation_number)
+    state_2 = inital_states[2]
+    state_3 = inital_states[3]
+
+    # Define spin-adapted linear combinations
+    state_2_spin_adapted = comp_basis_superposition(
+        state_2, state_3, theta=+pi / 4, phi=0.0
+    )
+    state_3_spin_adapted = comp_basis_superposition(
+        state_2, state_3, theta=-pi / 4, phi=0.0
+    )
+
+    # Replace initial states with spin-adapted states. Needed as Ansatz is spin conserving
+    inital_states[2] = state_2_spin_adapted
+    inital_states[3] = state_3_spin_adapted
+
     mc = vqemcscf.VQECASCI(
         mf,
-        2,
-        2,
+        n_electron,
+        n_orbitals,
         optimizer=LBFGS(),
+        inital_states=inital_states,
         ansatz=Ansatz.GateFabric,
         layers=2,
-        excitation_number=3,
+        excitation_number=inital_states,
     )
+
+    # Create reference CASCI values
     mc.kernel()
+    refmc = mcscf.CASCI(mf, n_orbitals, n_electron)
+    refmc.fcisolver.nroots = excitation_number
+    refmc.kernel()
 
-    # refmc = mcscf.CASCI(mf, 2, 2)
-    # refmc.fcisolver.nroots = 4
-    # refmc.kernel()
-    # print(refmc.e_tot)
+    def all_elements_within_threshold(array1, array2, threshold=10**-7):
+        for elem in array1:
+            if not any(abs(elem - other) <= threshold for other in array2):
+                return False
+        return True
 
-    ref_energies = [
-        -74.96569511044997,
-        -74.56710399202521,
-        -74.52886408322473,
-        -74.52886408322476,
-    ]
-    assert all(
-        utils.almost_equal(a, b) for a, b in zip(mc.fcisolver.energies, ref_energies)
-    )
+    assert all_elements_within_threshold(mc.fcisolver.energies, refmc.e_tot)
 
 
 # def test_vqecasci_h2o_4e_4o():
@@ -89,3 +114,6 @@ def test_vqecasscf_h2o_2e_2o():
     refmc.mc2step()
 
     assert utils.almost_equal(mc.e_tot, refmc.e_tot)
+
+
+test_ssvqecasci_h2o_2e_2o()


### PR DESCRIPTION
Te test was performed in this way since PySCF's CASCI only returns each excitation energy once and does not take multiplicity into account. However this test does not check if the returned energies are in ascending order. 

In fact, in the current implementation, the excited states may be returned not in ascending order.