### PR TITLE
21 bug fix fermion qubit mapping

### DIFF
--- a/chemqulacs/vqe/rdm.py
+++ b/chemqulacs/vqe/rdm.py
@@ -14,7 +14,7 @@ import numpy as np
 from openfermion.ops import FermionOperator
 
 
-def get_1rdm(state, fermion_qubit_mapping, estimator, n_electrons):
+def get_1rdm(state, fermion_qubit_mapping, estimator, n_electrons, sz=0):
     """
     Compute 1-RDM of a given state with user specfied fermion to qubit mapping.
 
@@ -33,7 +33,7 @@ def get_1rdm(state, fermion_qubit_mapping, estimator, n_electrons):
     _n_spin_orbitals = fermion_qubit_mapping.n_spin_orbitals(state.qubit_count)
     if version("quri-parts-openfermion") >= "0.19.0":
         op_mapper = fermion_qubit_mapping.get_of_operator_mapper(
-            n_spin_orbitals=_n_spin_orbitals, n_fermions=n_electrons, sz=0
+            n_spin_orbitals=_n_spin_orbitals, n_fermions=n_electrons, sz=sz
         )
     else:
         op_mapper = fermion_qubit_mapping.get_of_operator_mapper(
@@ -56,7 +56,7 @@ def get_1rdm(state, fermion_qubit_mapping, estimator, n_electrons):
     return ret
 
 
-def get_2rdm(state, fermion_qubit_mapping, estimator, n_electrons):
+def get_2rdm(state, fermion_qubit_mapping, estimator, n_electrons, sz=0):
     """
     Compute 2-RDM of a given state with user specfied fermion to qubit mapping.
 
@@ -74,7 +74,7 @@ def get_2rdm(state, fermion_qubit_mapping, estimator, n_electrons):
     _n_spin_orbitals = fermion_qubit_mapping.n_spin_orbitals(state.qubit_count)
     if version("quri-parts-openfermion") >= "0.19.0":
         op_mapper = fermion_qubit_mapping.get_of_operator_mapper(
-            n_spin_orbitals=_n_spin_orbitals, n_fermions=n_electrons, sz=0
+            n_spin_orbitals=_n_spin_orbitals, n_fermions=n_electrons, sz=sz
         )
     else:
         op_mapper = fermion_qubit_mapping.get_of_operator_mapper(

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -380,6 +380,7 @@ def generate_initial_states(
         initial_states.append(state_mapper(occupied_indices))
     return initial_states
 
+
 # ======================
 class VQECI(object):
     """

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -24,13 +24,13 @@ from pyscf import ao2mo
 from quri_parts.algo.ansatz import HardwareEfficient, SymmetryPreserving
 from quri_parts.algo.optimizer import Adam, OptimizerStatus
 from quri_parts.braket.backend import BraketSamplingBackend
-from quri_parts.chem.utils.spin import occupation_state_sz
 from quri_parts.chem.ansatz import (
     AllSinglesDoubles,
     GateFabric,
     ParticleConservingU1,
     ParticleConservingU2,
 )
+from quri_parts.chem.utils.spin import occupation_state_sz
 from quri_parts.circuit import LinearMappedUnboundParametricQuantumCircuit
 from quri_parts.core.estimator import (
     ConcurrentParametricQuantumEstimator,

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -218,7 +218,7 @@ def _get_active_hamiltonian(h1, h2, norb, ecore):
 
 def _create_concurrent_estimators(
     backend: Backend, shots_per_iter: int
-    ) -> tuple[
+) -> tuple[
     ConcurrentQuantumEstimator[CircuitQuantumState],
     ConcurrentParametricQuantumEstimator[ParametricCircuitQuantumState],
 ]:

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -216,7 +216,9 @@ def _get_active_hamiltonian(h1, h2, norb, ecore):
     return active_hamiltonian
 
 
-def _create_concurrent_estimators(backend: Backend, shots_per_iter: int) -> tuple[
+def _create_concurrent_estimators(
+    backend: Backend, shots_per_iter: int
+    ) -> tuple[
     ConcurrentQuantumEstimator[CircuitQuantumState],
     ConcurrentParametricQuantumEstimator[ParametricCircuitQuantumState],
 ]:

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -9,6 +9,7 @@
 # limitations under the License.
 
 # type:ignore
+import warnings
 from enum import Enum, auto
 from importlib.metadata import version
 from itertools import combinations, product

--- a/chemqulacs/vqe/vqeci.py
+++ b/chemqulacs/vqe/vqeci.py
@@ -445,7 +445,6 @@ class VQECI(object):
         self.mol = mol
         self.fermion_qubit_mapping = fermion_qubit_mapping
         self.opt_param = None  # to be used to store the optimal parameter for the VQE
-        self.initial_states: list = [None]
         self.opt_states: list = [None]
         self.n_qubit: int = None
         self.n_orbitals: int = None


### PR DESCRIPTION
A corrected version of the fermion qubit mapping update is required during the quri_part update. This should also take care of different spin configurations during the initial state preparation during SSVQE and VQE.  